### PR TITLE
Fix readme badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![GitHub License](https://img.shields.io/github/license/sohunpatel/ancs-desktop)[./LICENSE]
-![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/sohunpatel/ancs-desktop)[https://github.com/sohunpatel/ancs-desktop/issues]
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/sohunpatel/ancs-desktop/rust.yml)[https://github.com/sohunpatel/ancs-desktop/actions]
+[![GitHub License](https://img.shields.io/github/license/sohunpatel/ancs-desktop)](./LICENSE)
+[![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/sohunpatel/ancs-desktop)](https://github.com/sohunpatel/ancs-desktop/issues)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/sohunpatel/ancs-desktop/rust.yml)](ttps://github.com/sohunpatel/ancs-desktop/actions)
 
 # ANCS for Desktop
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub License](https://img.shields.io/github/license/sohunpatel/ancs-desktop)](./LICENSE)
 [![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/sohunpatel/ancs-desktop)](https://github.com/sohunpatel/ancs-desktop/issues)
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/sohunpatel/ancs-desktop/rust.yml)](ttps://github.com/sohunpatel/ancs-desktop/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/sohunpatel/ancs-desktop/rust.yml)](https://github.com/sohunpatel/ancs-desktop/actions)
 
 # ANCS for Desktop
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![GitHub License](https://img.shields.io/github/license/sohunpatel/ancs-desktop)
-![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/sohunpatel/ancs-desktop)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/sohunpatel/ancs-desktop/rust.yml)
+![GitHub License](https://img.shields.io/github/license/sohunpatel/ancs-desktop)[./LICENSE]
+![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/sohunpatel/ancs-desktop)[https://github.com/sohunpatel/ancs-desktop/issues]
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/sohunpatel/ancs-desktop/rust.yml)[https://github.com/sohunpatel/ancs-desktop/actions]
 
 # ANCS for Desktop
 


### PR DESCRIPTION
Right now, the links in the README just point to the actual images. They should point to the actual thing they reference (i.e. the license badge should open the LICENSE).